### PR TITLE
Fix markdown incompatibility

### DIFF
--- a/source/standards/api-documentation.html.md.erb
+++ b/source/standards/api-documentation.html.md.erb
@@ -16,4 +16,6 @@ commiting some additional information about the new service.
 See the [README](https://github.com/hmcts/reform-api-docs/blob/master/README.md) 
 for information on how to do this.
 
-[![API Docs](/images/api-docs-preview.png)](https://hmcts.github.io/reform-api-docs/)
+<a rel="noopener" target="_blank" title="API Docs" href="https://hmcts.github.io/reform-api-docs">
+    <img src="/images/api-docs-preview.png"/>
+</a>


### PR DESCRIPTION
Daring fireball doesn't support images linking to a place that aren't
the image