### PR TITLE
RPE-927 Guidance on pull requests

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -6,10 +6,12 @@ title: The HMCTS way
 
 ## How to build software
 
-The following standards help you build your service, for example choosing consistent names or an appropriate programming language. Find out about:
+The following standards help you build your service, 
+for example choosing consistent names or an appropriate programming language. Find out how we do:
 
-* [documenting apis](standards/api-documentation.html)
-* [our api standards](standards/apis.html)
+* [api documentation](standards/api-documentation.html)
+* [api standards](standards/apis.html)
+* [pull requests](ways-of-working/pull-requests.html)
 
 <!-- 
 

--- a/source/ways-of-working/pull-requests.html.md.erb
+++ b/source/ways-of-working/pull-requests.html.md.erb
@@ -62,9 +62,12 @@ All developers in the team should be reviewing, junior developers to tech lead.
 Code review isn’t just about improving the code and the solution being correct, it is also about 
 sharing knowledge of the code and different techniques that can be used in software engineering.
 
+If you know that someone has particular experience in an area, send the PR to them and ask if they would be able to review it when they have time.
+
 ## Review techniques
 
 * think "how could I make it easier for myself if I was reviewing it?"
+* pre-empt the reviewer by explaining (as comments) on your PR any compromises / or limitations that your implementation has
 * if there’s conflict occurring on the PR on the next steps to proceed on it, take it offline, go sit next to the person, chat on slack or call them
   agree the next step, and involve someone else if needed, post the result on the PR so that other people can see why the direction has changed.
 

--- a/source/ways-of-working/pull-requests.html.md.erb
+++ b/source/ways-of-working/pull-requests.html.md.erb
@@ -7,14 +7,21 @@ review_in: 3 months
 # <%= current_page.data.title %>
 
 As a PR writer I will:
+
 - keep PRs small
 
 As a PR reviewer I will:
+
 - make an effort to review as soon as I get a second.
 - approve, as long as it’s better than before
 - favour suggestions over rejections, particularly when a multipart PR is indicated
 
-All code at HMCTS must be reviewed by at least one person
+We practise code review on all changes at HMCTS to:
+
+- improve code quality
+- get team buy in on changes
+- validate change correctness
+- knowledge sharing
 
 Pull requests should not be opened when everything is finished.
 They should be opened as soon as you have something to show.

--- a/source/ways-of-working/pull-requests.html.md.erb
+++ b/source/ways-of-working/pull-requests.html.md.erb
@@ -48,6 +48,12 @@ they should be done after every break, before you start a new ticket or after yo
 
 Once you make your review comments especially if you block the merge you need to be ready to respond quickly to follow up comments so as not to hold up the person who has created the PR.
 
+## Who should review
+
+All developers in the team should be reviewing, junior developers to tech lead.
+Code review isn’t just about improving the code and the solution being correct, it is also about 
+sharing knowledge of the code and different techniques that can be used in software engineering.
+
 ## Review techniques
 
 * think "how could I make it easier for myself if I was reviewing it?"

--- a/source/ways-of-working/pull-requests.html.md.erb
+++ b/source/ways-of-working/pull-requests.html.md.erb
@@ -144,7 +144,7 @@ Please remove this line and everything above and fill the following sections:
 
 **Does this PR introduce a breaking change?** (check one with "x")
 
-\``` (remove backslack and this comment when copy pasting)
+\``` (remove backslash and this comment when copy pasting)
 [ ] Yes
 [ ] No
 \```

--- a/source/ways-of-working/pull-requests.html.md.erb
+++ b/source/ways-of-working/pull-requests.html.md.erb
@@ -1,0 +1,110 @@
+---
+title: Pull requests
+last_reviewed_on: 2019-02-08
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+As a PR writer I will:
+- keep PRs small
+
+As a PR reviewer I will:
+- make an effort to review as soon as I get a second.
+- approve, as long as it’s better than before
+- favour suggestions over rejections, particularly when a multipart PR is indicated
+
+All code at HMCTS must be reviewed by at least one person
+
+Pull requests should not be opened when everything is finished.
+They should be opened as soon as you have something to show.
+
+Leaving it to the last minute leaves a lot of pressure to the reviewer, 
+often someone is told the code is done but they aren’t 
+told that the review hasn’t happened, pressure comes on to ship the code but there’s design problems
+ in it that need addressing, this could take hours, or days.
+
+## Size
+The smaller your pull request the easier it is to review, to test and the safer it is to send to production.
+Separating your changes out is a great skill to practice, some tips:
+
+* don’t make unrelated changes in a PR, you should still make the change if you think it improves the code
+Just take the 10 minutes to create a new branch and open a separate PR, it can be quickly merged and you can continue with your task
+* refactor the code to make your change easier first
+* avoid unrelated whitespace changes if possible, they distract the reviewer and can cause conflicts with other people working in similar areas
+* look at the code before you start coding and see roughly what you need to do, perhaps do this with another developer, this can also make the review easier that on
+    if two developers were involved in the design there’s more buy in
+
+## When should review happen
+Reviews need to happen often, otherwise you will build up a backlog of changes.
+Before you start your task for the day check all the open PRs to see if there’s any code that needs a review or if someone needs a bit of help.
+The daily reminder can be automated by slack bot
+
+```
+/remind #my-pr-channel every weekday at 8:30am Why not start the day with coffee and reviewing code? :wink: Link in channel topic
+```
+But importantly reviews should not happen just first thing in the morning, 
+they should be done after every break, before you start a new ticket or after you’ve opened a PR yourself.
+
+Once you make your review comments especially if you block the merge you need to be ready to respond quickly to follow up comments so as not to hold up the person who has created the PR.
+
+## Review techniques
+
+* think "how could I make it easier for myself if I was reviewing it?"
+* if there’s conflict occurring on the PR on the next steps to proceed on it, take it offline, go sit next to the person, chat on slack or call them
+  agree the next step, and involve someone else if needed, post the result on the PR so that other people can see why the direction has changed.
+
+## How long should a PR be open
+
+Pull requests should be small and often, if it is open for more than 2-3 days there is probably something wrong.
+It is much better to have work flowing quickly than a backlog of work building up.
+You’re introducing a much riskier change and will have to do a lot more work to get it merged, satisfying reviewers
+and resolving conflicts due to other people’s merges.
+
+
+## Tooling to help
+
+In order to reduce the length of time PRs are open, 
+the cognitive load on having to see them all the time, 
+wonder whether they should be merged, and the cost of running any infrastructure related to the PRs.
+
+We use [probot-stale](https://probot.github.io/apps/stale/) to automate reminders about PRs and close them if no response or further work happens on it.
+
+We recommend config like:
+
+```yaml
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 7
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 4
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - dependencies
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue is being closed automatically as it was stale
+```
+
+You can tune the numbers slightly but please make sure pull requests are closed within 2 weeks
+If you have a PR that needs to stay around because you are demoing it or some other valid reason
+you can add to the configuration a permanent label such as `demoing` this will never become stale
+
+These should be reviewed regularly and closed if no longer required.
+
+Note that you don’t have to finish the PR within the period you set, it is the time from the last commit or activity on the PR
+and you can add a comment or remove the label on the PR if it is not actually stale.
+
+## Additional reading
+Highly recommend reading at least the hackernoon article, some very good points there:
+
+- [https://hackernoon.com/the-art-of-pull-requests-6f0f099850f9](https://hackernoon.com/the-art-of-pull-requests-6f0f099850f9)
+- [https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests](https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests)
+- [https://github.community/t5/Support-Protips/Best-practices-for-pull-requests/ba-p/4104](https://github.community/t5/Support-Protips/Best-practices-for-pull-requests/ba-p/4104)

--- a/source/ways-of-working/pull-requests.html.md.erb
+++ b/source/ways-of-working/pull-requests.html.md.erb
@@ -34,6 +34,7 @@ Just take the 10 minutes to create a new branch and open a separate PR, it can b
 * avoid unrelated whitespace changes if possible, they distract the reviewer and can cause conflicts with other people working in similar areas
 * look at the code before you start coding and see roughly what you need to do, perhaps do this with another developer, this can also make the review easier that on
     if two developers were involved in the design there’s more buy in
+* mention in your PR description that there is going to be more PRs and what is still to come
 
 ## When should review happen
 Reviews need to happen often, otherwise you will build up a backlog of changes.
@@ -70,6 +71,7 @@ and resolving conflicts due to other people’s merges.
 
 ## Tooling to help
 
+### Stale PRs
 In order to reduce the length of time PRs are open, 
 the cognitive load on having to see them all the time, 
 wonder whether they should be merged, and the cost of running any infrastructure related to the PRs.
@@ -107,6 +109,39 @@ These should be reviewed regularly and closed if no longer required.
 
 Note that you don’t have to finish the PR within the period you set, it is the time from the last commit or activity on the PR
 and you can add a comment or remove the label on the PR if it is not actually stale.
+
+### Templates for PRs
+
+Our standard template for PRs is:
+
+```markdown
+**Before creating a pull request make sure that:**
+
+- [ ] commit messages are meaningful and follow good commit message guidelines
+- [ ] README and other documentation has been updated / added (if needed)
+- [ ] tests have been updated / new tests has been added (if needed)
+
+Please remove this line and everything above and fill the following sections:
+
+
+### JIRA link (if applicable) ###
+
+
+
+### Change description ###
+<!-- Include what your change is here, any testing you have done, etc -->
+
+
+**Does this PR introduce a breaking change?** (check one with "x")
+
+\``` (remove backslack and this comment when copy pasting)
+[ ] Yes
+[ ] No
+\```
+
+```
+You should start with this and adopt for your needs
+
 
 ## Additional reading
 Highly recommend reading at least the hackernoon article, some very good points there:


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RPE-927

The initial driver for this PR was due to running out of resources on our preview AKS cluster, instead of forcing cleanup of old resources we're instead trying to address this problem at the source by cleaning up old PRs and automating the closure of PRs that have been sitting around for awhile

It seemed weird to write just about that, so I wrote about PRs in general and added the automation around closing PRs as a section inside the PR topic

Open to all feedback, happy to sit with someone and go through it, restructuring as needed etc