### PR TITLE
Try lock checkout to a version

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     name: Deploy
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:


### PR DESCRIPTION
to fix failed deployment from github action

Ref: https://github.com/JamesIves/github-pages-deploy-action/issues/48

If this doesn't work we can add our own access token to the github secrets and that will work apparently...