### PR TITLE
Drop openapi v2, make API standards more discoverable

### DIFF
--- a/source/api-docs/index.html.md.erb
+++ b/source/api-docs/index.html.md.erb
@@ -8,12 +8,11 @@ weight: 100
 # API Documentation
 
 All teams building APIs should be automatically publishing their documentation using the 
-[OpenAPI Specification 3.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md). The
-[OpenAPI Specification 2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md) may be used
-where version 3.0 cannot be used. For example, automated API gateway configuration may not support version 3.0 in which case
-version 2.0 may be used.
+[OpenAPI Specification 3.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md).
 Teams should use [these instructions](https://github.com/hmcts/reform-api-docs#publish-swagger-docs) 
 for publishing the swagger spec file to the [central api docs repository](https://github.com/hmcts/reform-api-docs).
+
+It's expected that all APIs follow our [API standards](/ways-of-working/standards/apis.html#api-design)
 
 A network map of microservice dependencies can be generated using this central repository by manually 
 commiting some additional information about the new service. 


### PR DESCRIPTION
azure bugs are long fixed with openapi v3