### PR TITLE
Update TLS certificates section in path to live

### DIFF
--- a/source/ways-of-working/path-to-live/tls-certificates.html.md.erb
+++ b/source/ways-of-working/path-to-live/tls-certificates.html.md.erb
@@ -1,18 +1,9 @@
 ---
 title: TLS certificates
-last_reviewed_on: 2021-03-19
+last_reviewed_on: 2021-09-14
 review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
 
-In non production environments we have a wildcard certificate for `*.<env>.platform.hmcts.net`,
-make sure you use a domain that matches that pattern.
-
-For production we require a cert per frontend application, this is procured by the Platform Operations team.
-
-You will need to fill out a form that can be found on the 
-[Requesting a SSL / TLS certificate](https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=947882506)
-confluence page, and then create a ticket on Jira in the DTSPO project.
-
-The vault the certificate should go into is cft-apps-prod.
+See [TLS certificates](../../information-security/certificate-automation.html)


### PR DESCRIPTION
I was conflicted on whether I should remove the section or just update the link, a user contacted me today confused as our advice conflicted with the main page.

![image](https://user-images.githubusercontent.com/21194782/133242075-9d24a5db-f845-4e92-900e-23712a6b51fd.png)
