### PR TITLE
Set slack domain and default owner

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -5,7 +5,7 @@ host: hmcts.github.io
 show_govuk_logo: false
 service_name: HMCTS
 service_link: https://github.com/hmcts
-phase: Beta
+phase: Live
 
 # Links to show on right-hand-side of header
 header_links:
@@ -36,3 +36,6 @@ prevent_indexing: false
 show_contribution_banner: true
 github_repo: hmcts/hmcts.github.io
 github_branch: source
+
+owner_slack_workspace: hmcts-reform
+default_owner_slack: platops-build-notices


### PR DESCRIPTION
Can be overridden per page if others own certain pages

![image](https://user-images.githubusercontent.com/21194782/135626667-f62a887e-1aa6-4cd9-b0cf-6b084417bfb9.png)
