### PR TITLE
Add https to config

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,5 +1,5 @@
 # Host to use for canonical URL generation (without trailing slash)
-host: hmcts.github.io
+host: https://hmcts.github.io
 
 # Header-related options
 show_govuk_logo: false


### PR DESCRIPTION
Fixes slack links not having protocol in them