### PR TITLE
Remove unneeded link

### DIFF
--- a/source/ways-of-working/new-component/index.html.md.erb
+++ b/source/ways-of-working/new-component/index.html.md.erb
@@ -19,4 +19,3 @@ weight: 3
 - [Flux config](gitops-flux.html#application-config-in-flux)
 - [Production approvals](https://github.com/hmcts/cnp-jenkins-config/blob/master/environment-approvals.yml)
 - [Path-to-live](../path-to-live/)
-- [Accessing apps via the VPN](connect-via-vpn.html)


### PR DESCRIPTION
Fixes https://github.com/hmcts/hmcts.github.io/issues/156

The page was poorly named before and not for general use, it's an advanced guide that not many people need, it was moved out of the new component section to https://hmcts.github.io/ways-of-working/guides/connect-via-vpn.html