### PR TITLE
DTSPO-7637 - update docs with pipeline channel error guidance

### DIFF
--- a/source/cloud-native-platform/onboarding/team/slack.html.md.erb
+++ b/source/cloud-native-platform/onboarding/team/slack.html.md.erb
@@ -38,9 +38,3 @@ Make sure you pick the Jenkins \[app] user:
 
 This can happen if your Slack invite was approved but you haven't been added to the SSO exclusion list.
 Get someone in your team to ask in the #pls-admins channel to check on your account.
-
-### I am getting an error message in my pipeline about `channel_not_found`
-
-When you want to send Jenkins pipeline notifications to a slack channel, you must make sure the Jenkins app has been added to the channel as shown in the image above.
-
-If you don't do this, you will receive the `channel_not_found` error message and the pipeline will fail.

--- a/source/cloud-native-platform/onboarding/team/slack.html.md.erb
+++ b/source/cloud-native-platform/onboarding/team/slack.html.md.erb
@@ -41,6 +41,6 @@ Get someone in your team to ask in the #pls-admins channel to check on your acco
 
 ### I am getting an error message in my pipeline about `channel_not_found`
 
-When you want to send Jenkins pipeline notifications to a slack channel, you must make sure the Jenkins app has been added to the channel. 
+When you want to send Jenkins pipeline notifications to a slack channel, you must make sure the Jenkins app has been added to the channel as shown in the image above.
 
 If you don't do this, you will receive the `channel_not_found` error message and the pipeline will fail.

--- a/source/cloud-native-platform/onboarding/team/slack.html.md.erb
+++ b/source/cloud-native-platform/onboarding/team/slack.html.md.erb
@@ -38,3 +38,9 @@ Make sure you pick the Jenkins \[app] user:
 
 This can happen if your Slack invite was approved but you haven't been added to the SSO exclusion list.
 Get someone in your team to ask in the #pls-admins channel to check on your account.
+
+### I am getting an error message in my pipeline about `channel_not_found`
+
+When you want to send Jenkins pipeline notifications to a slack channel, you must make sure the Jenkins app has been added to the channel. 
+
+If you don't do this, you will receive the `channel_not_found` error message and the pipeline will fail.

--- a/source/cloud-native-platform/troubleshooting/index.html.md.erb
+++ b/source/cloud-native-platform/troubleshooting/index.html.md.erb
@@ -141,6 +141,14 @@ Gradle is failing a functional test. To help get more information on why, you co
 
 And then reference this branch within your repo's [Jenkinsfile](https://github.com/hmcts/document-management-store-app/blob/646593336377fd59112b0b6c84fd223d0cb7832c/Jenkinsfile_CNP#L12)
 
+### Error message `channel_not_found`
+
+When you want to send Jenkins pipeline notifications to a slack channel, you must make sure the Jenkins app has been added to the channel.
+
+If you don't do this, you will receive the `channel_not_found` error message and the pipeline will fail.
+
+See the instructions on the [slack](/cloud-native-platform/onboarding/team/slack.html) section of the onboarding guide to find out how to do this.
+
 ## Debug Application Startup issues in AKS
 
 - There could be many reasons why applications could fail to startup like :


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-7637

### Change description ###
Update docs with info on how to fix a failing pipeline due to slack related `not_in_channel` error

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
