### PR TITLE
Update references to reform-api-docs

### DIFF
--- a/source/cloud-native-platform/api-docs/index.html.md.erb
+++ b/source/cloud-native-platform/api-docs/index.html.md.erb
@@ -9,20 +9,20 @@ weight: 100
 
 All teams building APIs should be automatically publishing their documentation using the
 [OpenAPI Specification 3.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md).
-Teams should use [these instructions](https://github.com/hmcts/reform-api-docs#publish-swagger-docs)
-for publishing the swagger spec file to the [central api docs repository](https://github.com/hmcts/reform-api-docs).
+Teams should use [these instructions](https://github.com/hmcts/cnp-api-docs#publish-swagger-docs)
+for publishing the swagger spec file to the [central api docs repository](https://github.com/hmcts/cnp-api-docs).
 
 It's expected that all APIs follow our [API standards](/cloud-native-platform/standards/apis.html#api-design).
 
 A network map of microservice dependencies can be generated using this central repository by manually
 committing some additional information about the new service.
 
-See the [README](https://github.com/hmcts/reform-api-docs/blob/master/README.md)
+See the [README](https://github.com/hmcts/cnp-api-docs/blob/master/README.md)
 for information on how to do this.
 
-<a rel="noopener" target="_blank" title="API Docs" href="https://hmcts.github.io/reform-api-docs">
+<a rel="noopener" target="_blank" title="API Docs" href="https://hmcts.github.io/cnp-api-docs">
     <img src="/images/api-docs-preview.png"/>
 </a>
-<a rel="noopener" target="_blank" title="API Docs" href="https://hmcts.github.io/reform-api-docs">
+<a rel="noopener" target="_blank" title="API Docs" href="https://hmcts.github.io/cnp-api-docs">
     View API documentation
 </a>


### PR DESCRIPTION
Updated the documentation to reflect the move from reform-api-docs to cnp-api-docs 