### PR TITLE
Update cft build monitor link

### DIFF
--- a/source/cloud-native-platform/onboarding/team/jenkins.html.md.erb
+++ b/source/cloud-native-platform/onboarding/team/jenkins.html.md.erb
@@ -18,7 +18,7 @@ The steps to be followed below depend on what business area your application is 
 
  2. Add a Jenkins build dashboard.
 
-    CFT: [cnp-flux-config](https://github.com/hmcts/cnp-flux-config/pull/7221)
+    CFT: [cnp-flux-config](https://github.com/hmcts/cnp-flux-config/blob/master/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml#L109)
 
     SDS: [sds-flux-config](https://github.com/hmcts/sds-flux-config/blob/79ca3abe8d7d67c2ab9749129a13a62c3cf653e4/apps/jenkins/jenkins/ptl/jenkins.yaml#L130)
 


### PR DESCRIPTION
### Change description ###
Update link to buildMonitor section of jenkins config for adding dashboard
Still pointing to Flux V1 config file

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
