### PR TITLE
Adding additional documentation about creating Azure resources in charts that use Azure DevOps for publishing

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -3,6 +3,7 @@ abfwhrf
 acedcyeygkgk
 aqda
 ard
+aso
 automerge
 bpdq
 brfxgseqf
@@ -21,6 +22,7 @@ ejdt
 enhbenftckhu
 ercybwaubzbmfn
 fkhfehdgahcrhbds
+flexibleserver
 frdsdtbc
 gufqadefbjgbhkhv
 hdgpbqdkafhmcse
@@ -29,5 +31,6 @@ hjd
 hpfvc
 knowledgebase
 pnp
+postgres
 roadmap
 vpn

--- a/source/cloud-native-platform/new-component/helm-chart.html.md.erb
+++ b/source/cloud-native-platform/new-component/helm-chart.html.md.erb
@@ -179,6 +179,43 @@ Add an azure-pipelines.yml file to your repo, using
 
 Ask on [#platops-help](https://hmcts-reform.slack.com/app_redirect?channel=platops-help) on slack for someone to setup the pipeline for you in AzureDevOps.
 
+#### Adding Azure Resources when using Azure DevOps charts
+
+Like Jenkins it is possible to add Azure resources to your charts when publishing via Azure DevOps.
+The following resources can be created:
+
+##### Postgres Databases
+
+Postgres databases can be added and test via the existing Postgres Instance in the `chart-tests` namespace.
+Guidance can be found in the [chart]( https://github.com/hmcts/chart-postgresq) repository.
+
+The database instance used for Azure DevOps builds is:
+
+```yaml
+postgresql:
+  flexibleserver: chart-tests-flexibleserver-postgres-preview
+```
+
+##### Blob Storage
+
+Blob storage is typically used by Application charts built via Jenkins but it is possible to use the blob storage [chart](https://github.com/hmcts/chart-blobstorage/tree/master) to test other charts via ADO.
+You must use the `chart-tests` resource group to test with Blob Storage:
+
+```yaml
+blobstorage:
+  resourceGroup: "chart-tests-aso-rg"
+```
+
+##### Service Bus
+
+Service bus topics and queues can be tested much in the same way as Postgres as there is an existing namespace for the `chart-tests` namespace.
+Guidance is available via the [chart](https://github.com/hmcts/chart-servicebus) repository.
+
+```yaml
+resourceGroup: chart-tests-aso-rg
+sbNamespace: chart-tests-servicebus
+```
+
 ## All charts
 
 We follow a standard naming convention of `chart-<name>` for all Helm charts, you can find a list of all

--- a/source/cloud-native-platform/new-component/helm-chart.html.md.erb
+++ b/source/cloud-native-platform/new-component/helm-chart.html.md.erb
@@ -187,7 +187,7 @@ The following resources can be created:
 ##### Postgres Databases
 
 Postgres databases can be added and test via the existing Postgres Instance in the `chart-tests` namespace.
-Guidance can be found in the [chart]( https://github.com/hmcts/chart-postgresq) repository.
+Guidance can be found in the [chart]( https://github.com/hmcts/chart-postgresql ) repository.
 
 The database instance used for Azure DevOps builds is:
 

--- a/source/cloud-native-platform/new-component/helm-chart.html.md.erb
+++ b/source/cloud-native-platform/new-component/helm-chart.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Helm chart
-last_reviewed_on: 2023-11-03
+last_reviewed_on: 2024-04-30
 review_in: 6 months
 weight: 3
 ---


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17358


### Change description ###
Adding additional documentation about creating Azure resources in charts that use Azure DevOps for publishing
