### PR TITLE
Add tf state error to shuttering docs

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -34,3 +34,6 @@ pnp
 postgres
 roadmap
 vpn
+xxxx
+xxxxxxxx
+xxxxxxxxxxxx

--- a/source/cloud-native-platform/path-to-live/shutter.html.md.erb
+++ b/source/cloud-native-platform/path-to-live/shutter.html.md.erb
@@ -166,4 +166,4 @@ See [azure-shutter-pages](https://github.com/hmcts/azure-shutter-pages) reposito
 
 If the pipeline fails with an error similar to the one below, you will need to import the offending record into terraform state. Documentation on how to do this can be found at [Import Block](https://developer.hashicorp.com/terraform/language/import) and [Terraform CLI](https://developer.hashicorp.com/terraform/cli/import/usage).
 
-`Error: A resource with the ID "/subscriptions/<SUBSCRIPTION>/resourceGroups/<RESOURCE_GROUP>/providers/Microsoft.Network/dnsZones/<DNS_ZONE>/CNAME/<DNS_RECORD>" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_dns_cname_record" for more information.`
+`Error: A resource with the ID "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/xxxx/providers/Microsoft.Network/dnsZones/xxxx/CNAME/xxxx" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_dns_cname_record" for more information.`

--- a/source/cloud-native-platform/path-to-live/shutter.html.md.erb
+++ b/source/cloud-native-platform/path-to-live/shutter.html.md.erb
@@ -156,6 +156,14 @@ To shutter all CFT services refer to these PRs as an example to use: [Shutter](h
 
 ## Shuttering Errors
 
+### 404 Not Found
+
 Shuttering error message - 404 Not Found - we couldn't find the page, please check the URL and try again - this occurs when browsing to folders after the main URL, which have not been set up for shuttering. Therefore teams need to update their custom shutter page.  
 
-See [azure-shutter-pages](https://github.com/hmcts/azure-shutter-pages) repository for examples, where there is shutter pages for further directories beyond the main URL.  For example: [et-pet](https://github.com/hmcts/azure-shutter-pages/tree/master/et-pet)
+See [azure-shutter-pages](https://github.com/hmcts/azure-shutter-pages) repository for examples, where there is shutter pages for further directories beyond the main URL. For example: [et-pet](https://github.com/hmcts/azure-shutter-pages/tree/master/et-pet)
+
+### A resource with ID... already exists
+
+If the pipeline fails with an error similar to the one below, you will need to import the offending record into terraform state. Documentation on how to do this can be found at https://developer.hashicorp.com/terraform/language/import.
+
+`Error: A resource with the ID "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/xxxx/providers/Microsoft.Network/dnsZones/xxxx/CNAME/xxxx" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_dns_cname_record" for more information.`

--- a/source/cloud-native-platform/path-to-live/shutter.html.md.erb
+++ b/source/cloud-native-platform/path-to-live/shutter.html.md.erb
@@ -164,6 +164,6 @@ See [azure-shutter-pages](https://github.com/hmcts/azure-shutter-pages) reposito
 
 ### A resource with ID... already exists
 
-If the pipeline fails with an error similar to the one below, you will need to import the offending record into terraform state. Documentation on how to do this can be found at https://developer.hashicorp.com/terraform/language/import.
+If the pipeline fails with an error similar to the one below, you will need to import the offending record into terraform state. Documentation on how to do this can be found at [Import Block](https://developer.hashicorp.com/terraform/language/import) and [Terraform CLI](https://developer.hashicorp.com/terraform/cli/import/usage).
 
 `Error: A resource with the ID "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/xxxx/providers/Microsoft.Network/dnsZones/xxxx/CNAME/xxxx" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_dns_cname_record" for more information.`

--- a/source/cloud-native-platform/path-to-live/shutter.html.md.erb
+++ b/source/cloud-native-platform/path-to-live/shutter.html.md.erb
@@ -166,4 +166,4 @@ See [azure-shutter-pages](https://github.com/hmcts/azure-shutter-pages) reposito
 
 If the pipeline fails with an error similar to the one below, you will need to import the offending record into terraform state. Documentation on how to do this can be found at [Import Block](https://developer.hashicorp.com/terraform/language/import) and [Terraform CLI](https://developer.hashicorp.com/terraform/cli/import/usage).
 
-`Error: A resource with the ID "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/xxxx/providers/Microsoft.Network/dnsZones/xxxx/CNAME/xxxx" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_dns_cname_record" for more information.`
+`Error: A resource with the ID "/subscriptions/<SUBSCRIPTION>/resourceGroups/<RESOURCE_GROUP>/providers/Microsoft.Network/dnsZones/<DNS_ZONE>/CNAME/<DNS_RECORD>" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_dns_cname_record" for more information.`


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###
- Adds a section under `Shuttering Errors` about DNS records falling out of terraform state.
- Issue came up on a recent release

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
