### PR TITLE
Fix shutdown/startup page

### DIFF
--- a/source/cloud-native-platform/environments/auto-shutdown.html.md.erb
+++ b/source/cloud-native-platform/environments/auto-shutdown.html.md.erb
@@ -18,8 +18,9 @@ See below the list of environments that are shut down outside of working hours o
 | ITHC | ITHC | 8pm | 7am |
 | Test | Perftest | 8pm | 7am |
 | Dev | Preview | 8pm | 7am |
+| PTL | PTL | 8pm | 7am |
 | PTLSBOX | PTLSBOX | 8pm | 7am |
-| Sandbox | Sandbox | OFF | OFF |
+| Sandbox | Sandbox | 8pm | 7am |
 
 
 ### How to start and stop the resources for an environment from pipeline

--- a/source/cloud-native-platform/new-component/feature-flags.html.md.erb
+++ b/source/cloud-native-platform/new-component/feature-flags.html.md.erb
@@ -34,8 +34,6 @@ see [onboarding](../onboarding/person/index.html) process to request access. You
 
 After you've logged in once you will be able to login from [app.launchdarkly.com](https://app.launchdarkly.com/).
 
-If you created your own trial account with your HMCTS email you will need to [delete the account](https://docs.launchdarkly.com/home/getting-started/your-account#deleting-your-trial-account).
-
 ### Documentation
 
 Documentation can be accessed directly from the [LaunchDarkly](https://docs.launchdarkly.com/home) website.


### PR DESCRIPTION
Updated schedule
https://github.com/hmcts/auto-shutdown/actions/runs/8929073643/job/24526044569

Removed a line from feature flag page, the deleting a trail account content has been fully removed from LD site - which seems to be because multiple accounts on one email address is supported https://docs.launchdarkly.com/home/account/multiple-accounts