### PR TITLE
Add docs for accessing a shuttered app

### DIFF
--- a/source/cloud-native-platform/path-to-live/shutter.html.md.erb
+++ b/source/cloud-native-platform/path-to-live/shutter.html.md.erb
@@ -154,6 +154,16 @@ To shutter all CFT services refer to these PRs as an example to use: [Shutter](h
 
 ![GitHub Revert Button](../images/gh-revert.png)
 
+## How to access your application when it is shuttered (For testing purposes only)
+
+When an application's shutter page is active, it's possible to access the application by adding an entry to your hosts file. This should only be used in situations where you need to test changes etc with the shutter page still active. You will need the Frontend Private IP from the Application Gateway, which can be retrieved from the Azure Portal. The example entry below is for our Plum application in sandbox, you can add a similar one for your service:
+
+```
+10.2.13.114 http://plum.sandbox.platform.hmcts.net
+```
+
+**Note:** You may need to clear your DNS cache for changes to take effect.
+
 ## Shuttering Errors
 
 ### 404 Not Found

--- a/source/cloud-native-platform/path-to-live/shutter.html.md.erb
+++ b/source/cloud-native-platform/path-to-live/shutter.html.md.erb
@@ -162,6 +162,8 @@ When an application's shutter page is active, it's possible to access the applic
 10.2.13.114 http://plum.sandbox.platform.hmcts.net
 ```
 
+Once your testing is complete, remove the entry and you should now see the shutter page again when trying to access the service.
+
 **Note:** You may need to clear your DNS cache for changes to take effect.
 
 ## Shuttering Errors


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###
- Adds a section explaining how shuttered apps can be accessed for testing changes etc
- Uses plum sbox as an example

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
