### PR TITLE
Update to allow new pages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ task :check_urls do
                 # Ignore pulls/branches as these do not translate to raw content
                 %r{github\.com/hmcts/(?=.*(?:pull|tree|commit))},
                 # This is a url that's generated each time we build the html by tech-docs-gem but does not exist
-                %r{https://github.com/hmcts/hmcts.github.io/blob/source/source/search/index.html}
+                %r{https://github.com/hmcts/hmcts.github.io/blob/source/source/search/index.html},
                 # This handles new files that haven't been merged to master branch yet for this repo in a PR
                 %r{(?=.*hmcts.github.io)(?=.*github)}
             ]

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,8 @@ task :check_urls do
                 %r{github\.com/hmcts/(?=.*(?:pull|tree|commit))},
                 # This is a url that's generated each time we build the html by tech-docs-gem but does not exist
                 %r{https://github.com/hmcts/hmcts.github.io/blob/source/source/search/index.html}
+                # This handles new files that haven't been merged to master branch yet for this repo in a PR
+                %r{(?=.*hmcts.github.io)(?=.*github)}
             ]
         })
 


### PR DESCRIPTION
New pages cause the link checker to fail because they have not been published yet

This is difficult to get around because they will only return 200 code when the publish step happens in the main build, but this can't happen unless the link checker is all happy...
To get around this, we can ignore URLs that are related to this single repo (not including internal hash) -- this allows you to check in new files that won't cause the link checker to break prematurely

Maybe a better way around this with more time to do with checking if a file is being updated or is new and using pipeline conditionals etc - not sure how nice this is with github actions though
<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
