### PR TITLE
Remove explicit permission grant

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,10 +6,6 @@ on:
     branches:
       - source
 
-# For check-spelling to comment in the pull request
-permissions:
-  pull-requests: write
-
 jobs:
   spellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The permission grant was added to try fixed forked PRs but there's more work needed, this breaks deployment (could be fixed by adding more permissions but lets roll this back till its a more conscious change)