### PR TITLE
Replace HMCTS API standards fork with upstream Zalando guidelines

### DIFF
--- a/source/standards/practices/apis.html.md.erb
+++ b/source/standards/practices/apis.html.md.erb
@@ -16,7 +16,7 @@ The source repository is [zalando/restful-api-guidelines](https://github.com/zal
 #### Personal data in URLs
 
 In addition to the Zalando guidelines, HMCTS services **must not** transmit
-[personal data](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/key-definitions/what-is-personal-data/)
+[personal data](https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/personal-information-what-is-it/what-is-personal-data/what-is-personal-data/)
 in URL paths or query strings. This information can be inadvertently exposed
 via client, network, and server logs.
 

--- a/source/standards/practices/apis.html.md.erb
+++ b/source/standards/practices/apis.html.md.erb
@@ -9,7 +9,19 @@ weight: 3
 
 ### API Design and implementation
 
-Use the [HMCTS RESTful API standards](https://hmcts.github.io/restful-api-standards/).
+Use the [Zalando RESTful API Guidelines](https://opensource.zalando.com/restful-api-guidelines/) as the reference standard for API design.
+
+The source repository is [zalando/restful-api-guidelines](https://github.com/zalando/restful-api-guidelines).
+
+#### Personal data in URLs
+
+In addition to the Zalando guidelines, HMCTS services **must not** transmit
+[personal data](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/key-definitions/what-is-personal-data/)
+in URL paths or query strings. This information can be inadvertently exposed
+via client, network, and server logs.
+
+Where personal data is required, transmit it in the request body or, where
+that is not possible (e.g. GET requests), in HTTP headers.
 
 ### Versioning
 


### PR DESCRIPTION
Replace HMCTS API standards fork with upstream Zalando guidelines

The hmcts/restful-api-standards fork has been inactive since 2020 and contained only one technical addition (personal data in URLs) over the upstream. Referencing the fork left teams following guidance that missed 6 years of upstream evolution including OpenAPI 3.1 and modern RFCs.

This change points to the actively maintained upstream guidelines and inlines the personal data rule directly on the page where it is more visible to engineers.