### PR TITLE
Add CFT OIDC authentication standard

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -218,6 +218,7 @@ Phishing
 pid
 pipeable
 pipefail
+PKCE
 placeholders
 platops
 plpgsql

--- a/source/standards/standards/authentication-and-authorization.html.md.erb
+++ b/source/standards/standards/authentication-and-authorization.html.md.erb
@@ -1,0 +1,24 @@
+---
+title: Authentication and authorization
+last_reviewed_on: 2026-06-08
+review_in: 12 months
+weight: 5
+---
+
+# <%= current_page.data.title %>
+
+CFT services should use OpenID Connect with CFT IDAM for user authentication.
+
+Authentication and authorization are separate concerns. OpenID Connect establishes the user identity. Services are responsible for their own authorization decisions.
+
+### OpenID Connect flows
+
+Use the authorization code flow for browser-based user authentication.
+
+Use PKCE where the client stack supports it.
+
+Use client credentials only for service-to-service authentication where no user is involved.
+
+Avoid password and implicit grants for new integrations.
+
+For implementation guidance, see the [OpenID Connect Guide for CFT Developers Using CFT IDAM](https://tools.hmcts.net/confluence/spaces/SISM/pages/1973296310/OpenID+Connect+Guide+for+CFT+Developers+Using+CFT+IDAM).


### PR DESCRIPTION
### Jira link
See [SIDM-9281](https://tools.hmcts.net/jira/browse/SIDM-9281).

### Change description
Added a new `Authentication and authorization` standard under engineering standards.
The standard says CFT services should use OpenID Connect with CFT IDAM for user authentication, while keeping authorization decisions owned by individual services.

### Testing done
N/A

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
